### PR TITLE
Use pkg-config

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include "callbacks.h"

--- a/camera.go
+++ b/camera.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include "callbacks.h"

--- a/context.go
+++ b/context.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include "callbacks.h"

--- a/photos.go
+++ b/photos.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include <stdlib.h>

--- a/types.go
+++ b/types.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include "callbacks.h"

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,6 @@
 package gphoto
 
-// #cgo LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lgphoto2 -lgphoto2_port
+// #cgo pkg-config: libgphoto2
 // #cgo CFLAGS: -I/usr/include
 // #include <gphoto2/gphoto2.h>
 // #include <stdlib.h>


### PR DESCRIPTION
Use pkg-config rather than hard coding paths to the gphoto library.

This will allow users of this library to customize the path to gphoto depending on their system without having to modify it.